### PR TITLE
added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
This pull request updates the testing configuration in `setup.cfg` to enhance verbosity, enable test specifications, and incorporate coverage reporting.

Testing configuration updates:

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L2-R7): Increased `nosetests` verbosity from 1 to 2, enabled test specifications (`with-spec=1` and `spec-color=1`), and added coverage reporting options (`with-coverage=1`, `cover-erase=1`, and `cover-package=service`).