### PR TITLE
Add update account endpoint and corresponding tests

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -3,8 +3,9 @@ Account Service
 
 This microservice handles the lifecycle of Accounts
 """
+
 # pylint: disable=unused-import
-from flask import jsonify, request, make_response, abort, url_for   # noqa; F401
+from flask import jsonify, request, make_response, abort, url_for  # noqa; F401
 from service.models import Account
 from service.common import status  # HTTP Status Codes
 from . import app  # Import Flask application
@@ -86,8 +87,22 @@ def get_accounts(account_id):
 ######################################################################
 # UPDATE AN EXISTING ACCOUNT
 ######################################################################
-
-# ... place you code here to UPDATE an account ...
+@app.route("/accounts/<int:account_id>", methods=["PUT"])
+def update_accounts(account_id):
+    """
+    Update an Account
+    This endpoint will update an Account based on the posted data
+    """
+    app.logger.info("Request to update an Account with id: %s", account_id)
+    account = Account.find(account_id)
+    if not account:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Account with id [{account_id}] could not be found.",
+        )
+    account.deserialize(request.get_json())
+    account.update()
+    return account.serialize(), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -40,7 +40,8 @@ class TestRoutes(TestCase):
         """It should return the home page"""
         response = self.client.get("/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("Welcome to the Account API Service", response.get_data(as_text=True))
+        data = response.get_json()
+        self.assertEqual(data["name"], "Account REST API Service")
 
     def test_invalid_route(self):
         """It should return 404 for an invalid route"""
@@ -164,3 +165,27 @@ class TestAccountService(TestCase):
         resp = self.client.get(f"{BASE_URL}/0")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
     
+    def test_update_account(self):
+        """It should Update an existing Account"""
+        # create an Account to update
+        test_account = AccountFactory()
+        resp = self.client.post(BASE_URL, json=test_account.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # update the account
+        new_account = resp.get_json()
+        new_account["name"] = "Something Known"
+        resp = self.client.put(f"{BASE_URL}/{new_account['id']}", json=new_account)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        updated_account = resp.get_json()
+        self.assertEqual(updated_account["name"], "Something Known")
+    
+    def test_update_account_not_found(self):
+        """It should return 404 when updating a non-existent account"""
+        # Use an ID that does not exist, e.g., 0 or a very large number
+        response = self.client.put(
+            f"{BASE_URL}/0",
+            json={"name": "Test"},
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This pull request introduces an update endpoint for the Account API service, along with corresponding unit tests to ensure its functionality. It also refines the home route test to validate the response structure more effectively.

### API Enhancements:
* Added a new `update_accounts` endpoint in `service/routes.py` to update an existing account based on provided data, including error handling for non-existent accounts.

### Testing Improvements:
* Added `test_update_account` and `test_update_account_not_found` unit tests in `tests/test_routes.py` to verify the behavior of the new update endpoint, including successful updates and handling of non-existent accounts.
* Modified the `test_home_route` in `tests/test_routes.py` to validate the JSON response structure instead of checking raw text.

### Code Cleanup:
* Added a comment to disable `pylint` warnings for unused imports in `service/routes.py`.
* 
<img width="732" height="306" alt="image" src="https://github.com/user-attachments/assets/185843b2-766a-4f36-a7c3-0d8f490c68d6" />
