### PR TITLE
Add list accounts endpoint and corresponding test case

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -61,8 +61,17 @@ def create_accounts():
 ######################################################################
 # LIST ALL ACCOUNTS
 ######################################################################
-
-# ... place you code here to LIST accounts ...
+@app.route("/accounts", methods=["GET"])
+def list_accounts():
+    """
+    List all Accounts
+    This endpoint will list all Accounts
+    """
+    app.logger.info("Request to list Accounts")
+    accounts = Account.all()
+    account_list = [account.serialize() for account in accounts]
+    app.logger.info("Returning [%s] accounts", len(account_list))
+    return jsonify(account_list), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -205,3 +205,11 @@ class TestAccountService(TestCase):
         """It should not allow an illegal method call"""
         resp = self.client.delete(BASE_URL)
         self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+    
+    def test_get_account_list(self):
+        """It should Get a list of Accounts"""
+        self._create_accounts(5)
+        resp = self.client.get(BASE_URL)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 5)


### PR DESCRIPTION
This pull request adds functionality to list all accounts via a new endpoint and includes corresponding unit tests to ensure the feature works as expected.

### Feature Addition: Listing Accounts

* [`service/routes.py`](diffhunk://#diff-5713d882378afffa24127e3725abe088589f9e300b01fa079a5a80179d2f6c1eL64-R74): Added a new endpoint `/accounts` with a `list_accounts` method to retrieve and return all accounts in JSON format. This includes logging the request and response details.

### Testing Enhancements

* [`tests/test_routes.py`](diffhunk://#diff-9ff873174f61a082827c26fc578df6fea7b1f6b51abbd415660645046e140b65R208-R215): Added a new test method `test_get_account_list` to verify the behavior of the `/accounts` endpoint. The test checks that the endpoint returns the correct HTTP status code and the expected number of accounts.

<img width="613" height="317" alt="image" src="https://github.com/user-attachments/assets/d29479e1-efa5-4258-9e41-25f60054d864" />
